### PR TITLE
Disable trace

### DIFF
--- a/GridCtrl.cpp
+++ b/GridCtrl.cpp
@@ -1816,7 +1816,7 @@ void CGridCtrl::OnDraw(CDC* pDC)
 #ifdef _DEBUG
 	LARGE_INTEGER iEndCount;
 	QueryPerformanceCounter(&iEndCount);
-	TRACE1("Draw counter ticks: %d\n", iEndCount.LowPart-iStartCount.LowPart);
+	// TRACE1("Draw counter ticks: %d\n", iEndCount.LowPart-iStartCount.LowPart);
 #endif
 
 }
@@ -5905,7 +5905,7 @@ CPoint CGridCtrl::GetPointClicked(int nRow, int nCol, const CPoint& point)
 
 void CGridCtrl::OnLButtonDblClk(UINT nFlags, CPoint point)
 {
-    TRACE0("CGridCtrl::OnLButtonDblClk\n");
+    // TRACE0("CGridCtrl::OnLButtonDblClk\n");
 
     CCellID cell = GetCellFromPt(point);
     if( !IsValid( cell) )

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
-Digistatic
-----------
+GridCtrl
+--------
 
 MFC Library for Grid control
 


### PR DESCRIPTION
Disable TRACE due to verbose logging of debug time

GridCtrl debugging may better to have its own debug macro instead of
_DEBUG