### PR TITLE
Add GridCtrl::SetItemFrColour and GridCell::SetFrameClr

### DIFF
--- a/GridCell.cpp
+++ b/GridCell.cpp
@@ -82,6 +82,7 @@ void CGridCell::Reset()
     m_nFormat = (DWORD)-1;       // Use default from CGridDefaultCell
     m_crBkClr = CLR_DEFAULT;     // Background colour (or CLR_DEFAULT)
     m_crFgClr = CLR_DEFAULT;     // Forground colour (or CLR_DEFAULT)
+    m_crFrClr = CLR_DEFAULT;     // Frame colour (or CLR_DEFAULT)
     m_nMargin = (UINT)-1;        // Use default from CGridDefaultCell
 
     delete m_plfFont;

--- a/GridCell.h
+++ b/GridCell.h
@@ -58,6 +58,7 @@ public:
     virtual void  SetFormat(DWORD nFormat)       { m_nFormat = nFormat; }                      
     virtual void  SetTextClr(COLORREF clr)       { m_crFgClr = clr;     }                          
     virtual void  SetBackClr(COLORREF clr)       { m_crBkClr = clr;     }                          
+    virtual void  SetFrameClr(COLORREF clr)      { m_crFrClr = clr;     }
     virtual void  SetFont(const LOGFONT* plf);
     virtual void  SetMargin(UINT nMargin)        { m_nMargin = nMargin; }
     virtual CWnd* GetEditWnd() const             { return m_pEditWnd;   }
@@ -72,6 +73,7 @@ public:
     virtual DWORD       GetFormat() const;
     virtual COLORREF    GetTextClr() const          { return m_crFgClr; } // TODO: change to use default cell
     virtual COLORREF    GetBackClr() const          { return m_crBkClr; }
+    virtual COLORREF    GetFrameClr() const         { return m_crFrClr; }
     virtual LOGFONT*    GetFont() const;
     virtual CFont*      GetFontObject() const;
     virtual UINT        GetMargin() const;
@@ -94,6 +96,7 @@ protected:
     DWORD      m_nFormat;
     COLORREF   m_crFgClr;
     COLORREF   m_crBkClr;
+    COLORREF   m_crFrClr;
     LOGFONT*   m_plfFont;
     UINT       m_nMargin;
 

--- a/GridCellBase.cpp
+++ b/GridCellBase.cpp
@@ -147,6 +147,8 @@ BOOL CGridCellBase::Draw(CDC* pDC, int nRow, int nCol, CRect rect,  BOOL bEraseB
         TextBkClr = GetBackClr();
     }
 
+    COLORREF FrameClr = GetFrameClr();
+
     // Draw cell background and highlighting (if necessary)
     if ( IsFocused() || IsDropHighlighted() )
     {
@@ -159,9 +161,9 @@ BOOL CGridCellBase::Draw(CDC* pDC, int nRow, int nCol, CRect rect,  BOOL bEraseB
             bEraseBkgnd = TRUE;
         }
 
-        rect.right++; rect.bottom++;    // FillRect doesn't draw RHS or bottom
         if (bEraseBkgnd)
         {
+            rect.right++; rect.bottom++;    // FillRect doesn't draw RHS or bottom
             TRY 
             {
                 CBrush brush(TextBkClr);
@@ -172,38 +174,12 @@ BOOL CGridCellBase::Draw(CDC* pDC, int nRow, int nCol, CRect rect,  BOOL bEraseB
                 //e->ReportError();
             }
             END_CATCH
-        }
-
-        // Don't adjust frame rect if no grid lines so that the
-        // whole cell is enclosed.
-        if(pGrid->GetGridLines() != GVL_NONE)
-        {
-            rect.right--;
-            rect.bottom--;
+            rect.right--; rect.bottom--;
         }
 
         if (pGrid->GetFrameFocusCell())
         {
-                // Use same color as text to outline the cell so that it shows
-                // up if the background is black.
-            TRY 
-            {
-                CBrush brush(TextClr);
-                pDC->FrameRect(rect, &brush);
-            }
-            CATCH(CResourceException, e)
-            {
-                //e->ReportError();
-            }
-            END_CATCH
-        }
-        pDC->SetTextColor(TextClr);
-
-        // Adjust rect after frame draw if no grid lines
-        if(pGrid->GetGridLines() == GVL_NONE)
-        {
-            rect.right--;
-            rect.bottom--;
+            FrameClr = TextClr;
         }
 
 		//rect.DeflateRect(0,1,1,1);  - Removed by Yogurt
@@ -225,6 +201,38 @@ BOOL CGridCellBase::Draw(CDC* pDC, int nRow, int nCol, CRect rect,  BOOL bEraseB
             rect.right--; rect.bottom--;
         }
         pDC->SetTextColor(TextClr);
+    }
+
+    if (FrameClr != CLR_DEFAULT) {
+        // Don't adjust frame rect if no grid lines so that the
+        // whole cell is enclosed.
+        if (pGrid->GetGridLines() == GVL_NONE)
+        {
+            rect.right++;
+            rect.bottom++;
+        }
+
+        // Use same color as text to outline the cell so that it shows
+        // up if the background is black.
+        TRY
+        {
+            CBrush brush(FrameClr);
+            pDC->FrameRect(rect, &brush);
+        }
+        CATCH(CResourceException, e)
+        {
+            //e->ReportError();
+        }
+        END_CATCH
+
+        pDC->SetTextColor(TextClr);
+
+        // Adjust rect after frame draw if no grid lines
+        if (pGrid->GetGridLines() == GVL_NONE)
+        {
+            rect.right--;
+            rect.bottom--;
+        }
     }
 
     // Draw lines only when wanted

--- a/GridCellBase.h
+++ b/GridCellBase.h
@@ -93,6 +93,7 @@ public:
     virtual void SetFormat(DWORD /* nFormat */)             = 0 ;
     virtual void SetTextClr(COLORREF /* clr */)             = 0 ;
     virtual void SetBackClr(COLORREF /* clr */)             = 0 ;
+    virtual void SetFrameClr(COLORREF /* clr */)            = 0 ;
     virtual void SetFont(const LOGFONT* /* plf */)          = 0 ;
     virtual void SetMargin( UINT /* nMargin */)             = 0 ;
     virtual void SetGrid(CGridCtrl* /* pGrid */)            = 0 ;
@@ -106,6 +107,7 @@ public:
     virtual DWORD      GetFormat()     const                = 0 ;
     virtual COLORREF   GetTextClr()    const                = 0 ;
     virtual COLORREF   GetBackClr()    const                = 0 ;
+    virtual COLORREF   GetFrameClr()   const                = 0 ;
     virtual LOGFONT  * GetFont()       const                = 0 ;
     virtual CFont    * GetFontObject() const                = 0 ;
     virtual CGridCtrl* GetGrid()       const                = 0 ;

--- a/GridCtrl.cpp
+++ b/GridCtrl.cpp
@@ -4829,6 +4829,30 @@ COLORREF CGridCtrl::GetItemFgColour(int nRow, int nCol) const
     return pCell->GetTextClr();
 }
 
+BOOL CGridCtrl::SetItemFrColour(int nRow, int nCol, COLORREF cr /* = CLR_DEFAULT */)
+{
+    if (GetVirtualMode())
+        return FALSE;
+
+    CGridCellBase* pCell = GetCell(nRow, nCol);
+    ASSERT(pCell);
+    if (!pCell)
+        return FALSE;
+
+    pCell->SetFrameClr(cr);
+    return TRUE;
+}
+
+COLORREF CGridCtrl::GetItemFrColour(int nRow, int nCol) const
+{
+    CGridCellBase* pCell = GetCell(nRow, nCol);
+    ASSERT(pCell);
+    if (!pCell)
+        return 0;
+
+    return pCell->GetFrameClr();
+}
+
 BOOL CGridCtrl::SetItemFont(int nRow, int nCol, const LOGFONT* plf)
 {
     if (GetVirtualMode())

--- a/GridCtrl.h
+++ b/GridCtrl.h
@@ -391,6 +391,8 @@ public:
     COLORREF GetItemBkColour(int nRow, int nCol) const;
     BOOL   SetItemFgColour(int nRow, int nCol, COLORREF cr = CLR_DEFAULT);
     COLORREF GetItemFgColour(int nRow, int nCol) const;
+    BOOL   SetItemFrColour(int nRow, int nCol, COLORREF cr = CLR_DEFAULT);
+    COLORREF GetItemFrColour(int nRow, int nCol) const;
     BOOL SetItemFont(int nRow, int nCol, const LOGFONT* lf);
     const LOGFONT* GetItemFont(int nRow, int nCol);
 


### PR DESCRIPTION
GridCtrl already had a feature to draw the frame of the selected cell.

This patch extends the feature to support default frame color when it is not selected.